### PR TITLE
Version 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
 # Changelog
 
 Ce fichier répertorie les changements entre différentes versions d'un schéma.
+
+## Version 0.0.1 - 2019-06-28
+Publication initiale.

--- a/README.md
+++ b/README.md
@@ -1,18 +1,20 @@
 # Schéma des lieux de covoiturage
 
-Le Point d’accès national aux données de transport ([transport.data.gouv.fr](https://transport.data.gouv.fr])) réalise une consolidation régulière des fichiers déposés sur data.gouv.fr avec le mot-clé `covoiturage` respectant le format de référence décrit ci-dessous. 
-
-Les collectivités territoriales peuvent y signaler la localisation des lieux pertinents (aires de covoiturage, parkings, délaissés routiers, etc) pour commencer ou terminer un trajet en covoiturage. Ces données sont précieuses, notamment pour les application de covoiturage qui peuvent ainsi assurer à leurs usagers une information fiable sur les lieux où ils peuvent s’arrêter et stationner en toute sécurité.
-
-Ces lieux de covoiturage ne concernent que les offres qui permettent de stationner gratuitement.
+Ce schéma permet de modéliser des lieux pertinents (aires de covoiturage, parkings, délaissés routiers, etc) pour commencer ou terminer un trajet en covoiturage. Ces lieux de covoiturage ne concernent que les offres qui permettent de stationner gratuitement.
 
 ## Finalité
-Dans le but de constituer un répertoire national des lieux de covoiturage, ouvert et accessible à tous, les collectivités peuvent transmettre systématiquement, sous forme de tableau mis à jour, les données relatives aux lieux qu’elles considèrent pertinents pour les covoitureurs.
+Les lieux de covoiturage sont des données précieuses, notamment pour les application de covoiturage qui peuvent ainsi assurer à leurs usagers une information fiable sur les lieux où ils peuvent s'arrêter et stationner en toute sécurité.
 
-## Format des fichiers
+## Transmission des données
+Dans le but de constituer un répertoire national des lieux de covoiturage, ouvert et accessible à tous, les collectivités peuvent transmettre systématiquement, sous forme de tableau mis à jour, les données relatives aux lieux qu'elles considèrent pertinents pour les covoitureurs.
+
+### Format des fichiers
 Le fichier doit être encodé en UTF-8 et utiliser le point-virgule comme séparateur de colonnes. L'en-tête de colonne sur la première ligne est obligatoire. Tous les champs sont obligatoires ; si la donnée n'est pas disponible, la colonne doit être présente et vide.
 
-Nom du fichier : `AAAAMMJJ_idproducteur_lieuxcovoit.csv` où `idproducteur` est le SIREN de la collectivité productrice des données, par exemple pour le département de l’Ain `20191013_220100010_lieuxcovoit.csv`.
+Nom du fichier : `AAAAMMJJ_idproducteur_lieuxcovoit.csv` où `idproducteur` est le SIREN de la collectivité productrice des données, par exemple pour le département de l'Ain `20191013_220100010_lieuxcovoit.csv`.
 
-## Mises à jour
+### Mises à jour
 Les mises à jour sont effectuées à partir du fichier communiqué précédemment et en reprennent, en les modifiant le cas échéant, les données qui y figurent déjà.
+
+## Consolidation
+Le Point d'accès national aux données de transport ([transport.data.gouv.fr](https://transport.data.gouv.fr)) réalise une consolidation régulière des fichiers déposés sur [data.gouv.fr](https://data.gouv.fr) avec le mot-clé `covoiturage` respectant le format de référence décrit ici.

--- a/schema.json
+++ b/schema.json
@@ -24,7 +24,7 @@
         },
         {
             "name":"nom_lieu",
-            "description":"Le nom du lieu de covoiturage. Recommandation : inutile de répéter la nature du type de covoiturage.",
+            "description":"Le nom du lieu de covoiturage. Recommandation : inutile de répéter la nature du type de covoiturage",
             "example":"Les Romains",
             "type":"string",
             "constraints":{
@@ -33,7 +33,7 @@
         },
         {
             "name":"ad_lieu",
-            "description":"L'adresse du lieu compréhensible par le grand public pour assurer la coordination entre le passager et le conducteur. Exemple : \"3, rue de la gare\" ; pour les lieux proches des sorties d'autoroute ou de nationale : \"A11 sortie 7 Le Mans Nord\" ; pour les zones rurales sans adresse : \"croisement de route 1 - route 2\" ou \"le long de route X après le passage à niveau\".",
+            "description":"L'adresse du lieu compréhensible par le grand public pour assurer la coordination entre le passager et le conducteur. Exemple : \"3, rue de la gare\" ; pour les lieux proches des sorties d'autoroute ou de nationale : \"A11 sortie 7 Le Mans Nord\" ; pour les zones rurales sans adresse : \"croisement de route 1 - route 2\" ou \"le long de route X après le passage à niveau\"",
             "example":"3, rue de la Gare",
             "type":"string",
             "constraints":{
@@ -78,7 +78,7 @@
         },
         {
             "name":"date_maj",
-            "description":"Date de dernière mise à jour des données. Notation ISO 8601",
+            "description":"Date de dernière mise à jour des données. Notation ISO 8601, format AAAA-MM-DD",
             "example":"2016-10-31",
             "type":"date",
             "format":"%Y-%m-%d",
@@ -97,7 +97,7 @@
         },
         {
             "name":"source",
-            "description":"Entité ayant fourni la donnée - sous format SIREN",
+            "description":"SIREN de l'entité ayant fourni la donnée",
             "example":"225300011",
             "type":"string",
             "constraints":{
@@ -149,7 +149,7 @@
         },
         {
             "name":"duree",
-            "description":"Si il existe une restriction sur la durée de stationnement autorisée, la durée maximale de stationnement autorisée exprimée en minutes.",
+            "description":"Si il existe une restriction sur la durée de stationnement autorisée, la durée maximale de stationnement autorisée exprimée en minutes",
             "example":"60",
             "type":"integer",
             "constraints":{
@@ -187,7 +187,7 @@
         {
             "name":"comm",
             "description":"Commentaires éventuels sur les commodités mises à disposition du grand public comme : le numéro de téléphone unique qui indique les services disponibles au moment de l'arrivée sur l'aire pour réaliser le dernier kilomètre ; la présence de prises 220V ou USB ; accès à du réseau (télécom, WiFi) ; sanitaires ; intermodalité en transports",
-            "example":"Présence de sanitaires et accès à de l'eau courante.",
+            "example":"Présence de sanitaires et accès à de l'eau courante",
             "type":"string",
             "constraints":{
                 "required":false


### PR DESCRIPTION
Propositions d'ajout de paramètre pour décrire une aire/lieu de covoiturage :

- stationnement vélo ouvert type arceau
- stationnement vélo fermé type box
- borne charge VE: type, nombre, ...
- connexion au transport public: distance à l'arrêt de bus/train le plus proche